### PR TITLE
ci: Add lint workflow and ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install uv
+        python -m uv pip install --system --upgrade pip wheel
+        uv pip install --system pytest coverage
+        uv pip install --system --strict --requirement requirements.lock
+
+    - name: List installed Python packages
+      run: python -m pip list
+
+    - name: Test with pytest and coverage
+      run: |
+        coverage run --module pytest tests/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Python checks
+name: Lint
 
 on:
   push:
@@ -7,28 +7,32 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Set up Python
-          uses: actions/setup-python@v3
+          uses: actions/setup-python@v5
           with:
             python-version: "3.x"
 
         - name: Install dependencies
           run: |
-            python -m pip install --upgrade pip
-            python -m pip install -r requirements-dev.txt
+            python -m pip install uv
+            python -m uv pip install --system --upgrade pip wheel
+            python -m uv pip install --system ruff black
+
+        - name: List installed Python packages
+          run: python -m pip list
 
         - name: Lint with ruff
           run: ruff check .
 
         - name: Check formatting with black
           run: black . --check --verbose
-
-        - name: Run unit tests
-          run: |
-            pytest


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Make the testing GitHub Actions workflow a seperate workflow from the linting
  workflow.
* Update GitHub Action versions to the latest major version tags.

At the moment this just runs the tests and coverage, but it doesn't report them at all, but as we don't have full tests yet this is left as a stub intentionally.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```
