### PR TITLE
Add notebooks to pre-process data and assign reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .venv
 __pycache__
 .coverage
+*.csv
+*.db
+*.json
+venv/
+*ipynb_checkpoints
+.DS_Store

--- a/assign_reviews.py
+++ b/assign_reviews.py
@@ -10,23 +10,25 @@ from scipy.optimize import Bounds, LinearConstraint, milp
 
 DEBUG = True
 
-def create_objective_fun(df_reviewers, df_submissions, tutorial_coeff):    
+
+def create_objective_fun(df_reviewers, df_submissions, tutorial_coeff):
     reviewers = df_reviewers.to_dict("records")
     submissions = df_submissions.to_dict("records")
-    
+
     n_reviewers = len(reviewers)
     n_submissions = len(submissions)
-    
+
     # Maximize the total number of reviews
     objective_fun = -np.ones((n_reviewers, n_submissions))
-    
+
     # Make tutorials more expensive to review
     for n, reviewer in enumerate(reviewers):
         objective_fun[n][df_submissions.track == "TUT"] *= tutorial_coeff
-    
+
     objective_fun = objective_fun.flatten()
 
     return objective_fun
+
 
 def create_lb_ub(reviewers, submissions, assign_tutorials_to_anyone):
     n_reviewers = len(reviewers)
@@ -34,7 +36,7 @@ def create_lb_ub(reviewers, submissions, assign_tutorials_to_anyone):
     # both zero if reviewer cannot review submission, both one if reviewer is assigned to submission
     lb = np.zeros((n_reviewers, n_submissions))  # lower bound
     ub = np.zeros((n_reviewers, n_submissions))  # upper bound
-    
+
     # Establish lower and upper bounds
     # reviewer cannot be assigned out of domain
     # reviewer must be re-assigned previous assignments
@@ -47,69 +49,72 @@ def create_lb_ub(reviewers, submissions, assign_tutorials_to_anyone):
             )
             no_conflict = submission["submission_id"] not in reviewer["conflicts_submission_ids"]
             ub[i, j] = in_domain and no_conflict
-    
+
             already_assigned = submission["submission_id"] in reviewer["assigned_submission_ids"]
             lb[i, j] = already_assigned
 
     return lb, ub
 
+
 def create_constraints(reviewers, submissions, min_reviews, max_reviews, min_reviewers, max_reviewers):
     n_reviewers = len(reviewers)
     n_submissions = len(submissions)
 
-    submission_constraints = np.zeros((n_submissions, n_reviewers, n_submissions))  # constraints on reviews per submission
+    submission_constraints = np.zeros(
+        (n_submissions, n_reviewers, n_submissions)
+    )  # constraints on reviews per submission
     reviewer_constraints = np.zeros(
         (n_reviewers, n_reviewers, n_submissions)
     )  # constraints on submissions per reviewer. 1 in all the places where reviewer could be assigned
-    
+
     # Constraints
     # each reviewer assigned < max reviews
     for i, reviewer in enumerate(reviewers):
         reviewer_constraints[i, i, :] = 1
     reviewer_constraints = reviewer_constraints.reshape(n_reviewers, -1)
-    
+
     # each paper assigned to 4 reviewers
     for j, _ in enumerate(submissions):
         submission_constraints[j, :, j] = 1
     submission_constraints = submission_constraints.reshape(n_submissions, -1)
-    
-    submission_per_reviewer_constraint = LinearConstraint(
-        reviewer_constraints, min_reviews, max_reviews
-    )
-    reviews_per_paper_constraint = LinearConstraint(
-        submission_constraints, min_reviewers, max_reviewers
-    )
+
+    submission_per_reviewer_constraint = LinearConstraint(reviewer_constraints, min_reviews, max_reviews)
+    reviews_per_paper_constraint = LinearConstraint(submission_constraints, min_reviewers, max_reviewers)
     constraints = [submission_per_reviewer_constraint, reviews_per_paper_constraint]
- 
+
     return constraints
 
-def solve_milp(df_reviewers, df_submissions, min_reviews, max_reviews, min_reviewers, max_reviewers, tutorial_coeff, assign_tutorials_to_anyone):
+
+def solve_milp(
+    df_reviewers,
+    df_submissions,
+    min_reviews,
+    max_reviews,
+    min_reviewers,
+    max_reviewers,
+    tutorial_coeff,
+    assign_tutorials_to_anyone,
+):
     reviewers = df_reviewers.to_dict("records")
     submissions = df_submissions.to_dict("records")
 
     objective_fun = create_objective_fun(df_reviewers, df_submissions, tutorial_coeff)
     lb, ub = create_lb_ub(reviewers, submissions, assign_tutorials_to_anyone)
     bounds = Bounds(lb.ravel(), ub.ravel())
-    constraints = create_constraints(
-        reviewers,
-        submissions,
-        min_reviews,
-        max_reviews,
-        min_reviewers,
-        max_reviewers
-    )
-    
+    constraints = create_constraints(reviewers, submissions, min_reviews, max_reviews, min_reviewers, max_reviewers)
+
     # Run MILP
     res = milp(objective_fun, integrality=True, bounds=bounds, constraints=constraints)
     print(res)
     n_reviewers = len(reviewers)
     n_submissions = len(submissions)
-    
+
     # %%
     if res.success:
         x = np.round(res.x).astype(bool)
         solution = x.reshape(n_reviewers, n_submissions)
         return solution
+
 
 # %%
 ############################
@@ -120,7 +125,8 @@ def format_and_output_result(df_reviewers, df_submissions, solution, post_fix=""
     submissions = df_submissions.to_dict("records")
 
     for reviewer, assignments in zip(reviewers, solution):
-        # reviewer["assigned_submission_ids"] = reviewer["assigned_submission_ids"] + df_submissions.submission_id[assignments].values.tolist()
+        # reviewer["assigned_submission_ids"] = reviewer["assigned_submission_ids"] + \
+        # df_submissions.submission_id[assignments].values.tolist()
         reviewer["assigned_submission_ids"] = df_submissions.submission_id[assignments].values.tolist()
         if DEBUG:
             # Check how many tutorials everyone got
@@ -130,23 +136,23 @@ def format_and_output_result(df_reviewers, df_submissions, solution, post_fix=""
             reviewer["tutorial_reviewer"] = "TUT" in reviewer["tracks"]
             # Check that each reviewer actually was assigned a submission in their domain
             reviewer["track_in_domain"] = [t in reviewer["tracks"] for t in df_submissions.track[assignments]]
-    
+
     if DEBUG:
         result = {reviewer["reviewer_id"]: sorted(reviewer["is_tutorial"]) for reviewer in reviewers}
-    
+
         with open(f"output/review-assignments-debug{post_fix}.json", "w") as fp:
             fp.write(json.dumps(result, indent=4))
-    
+
     result = {reviewer["reviewer_id"]: reviewer["assigned_submission_ids"] for reviewer in reviewers}
-    
+
     with open(f"output/review-assignments{post_fix}.json", "w") as fp:
         fp.write(json.dumps(result, indent=4))
-    
+
     for submission, assignments in zip(submissions, solution.T):
         submission["assigned_reviewer_ids"] = df_reviewers.reviewer_id[assignments].values.tolist()
-    
+
     result = {submission["submission_id"]: submission["assigned_reviewer_ids"] for submission in submissions}
-    
+
     with open(f"output/submission-assignments{post_fix}.json", "w") as fp:
         fp.write(json.dumps(result, indent=4))
 

--- a/assign_reviews.py
+++ b/assign_reviews.py
@@ -6,122 +6,148 @@
 import json
 
 import numpy as np
-import pandas as pd
 from scipy.optimize import Bounds, LinearConstraint, milp
-
-MIN_REVIEWS_PER_PERSON = 5
-MAX_REVIEWS_PER_PERSON = 9
-MIN_REVIEWERS_PER_SUBMISSION = 4
-MAX_REVIEWERS_PER_SUBMISSION = 4
-ASSIGN_TUTORIALS_TO_ANYONE = True
-TUTORIAL_COEFF = 0.8
 
 DEBUG = True
 
-df_submissions = pd.read_csv("2023_submissions_to_assign.csv")
-df_reviewers = pd.read_csv("2023_reviewers_to_assign.csv")
-
-df_submissions = df_submissions.assign(assigned_reviewer_ids=[[]] * len(df_submissions))
-df_reviewers = df_reviewers.assign(assigned_submission_ids=[[]] * len(df_reviewers))
-
-reviewers = df_reviewers.to_dict("records")
-submissions = df_submissions.to_dict("records")
-
-n_reviewers = len(reviewers)
-n_submissions = len(submissions)
-
-# Maximize the total number of reviews
-objective_fun = -np.ones((n_reviewers, n_submissions))
-
-if ASSIGN_TUTORIALS_TO_ANYONE:
+def create_objective_fun(df_reviewers, df_submissions, tutorial_coeff):    
+    reviewers = df_reviewers.to_dict("records")
+    submissions = df_submissions.to_dict("records")
+    
+    n_reviewers = len(reviewers)
+    n_submissions = len(submissions)
+    
+    # Maximize the total number of reviews
+    objective_fun = -np.ones((n_reviewers, n_submissions))
+    
     # Make tutorials more expensive to review
     for n, reviewer in enumerate(reviewers):
-        objective_fun[n][df_submissions.track == "TUT"] *= TUTORIAL_COEFF
+        objective_fun[n][df_submissions.track == "TUT"] *= tutorial_coeff
+    
+    objective_fun = objective_fun.flatten()
 
-objective_fun = objective_fun.flatten()
+    return objective_fun
 
-# both zero if reviewer cannot review submission, both one if reviewer is assigned to submission
-lb = np.zeros((n_reviewers, n_submissions))  # lower bound
-ub = np.zeros((n_reviewers, n_submissions))  # upper bound
+def create_lb_ub(reviewers, submissions, assign_tutorials_to_anyone):
+    n_reviewers = len(reviewers)
+    n_submissions = len(submissions)
+    # both zero if reviewer cannot review submission, both one if reviewer is assigned to submission
+    lb = np.zeros((n_reviewers, n_submissions))  # lower bound
+    ub = np.zeros((n_reviewers, n_submissions))  # upper bound
+    
+    # Establish lower and upper bounds
+    # reviewer cannot be assigned out of domain
+    # reviewer must be re-assigned previous assignments
+    for i, reviewer in enumerate(reviewers):
+        for j, submission in enumerate(submissions):
+            # each variable is assignment of a submission j to a reviewer i
+            # everyone can be assigned a tutorial because we're short on tutorial reviewers
+            in_domain = submission["track"] in reviewer["tracks"] or (
+                assign_tutorials_to_anyone and submission["track"] == "TUT"
+            )
+            no_conflict = submission["submission_id"] not in reviewer["conflicts_submission_ids"]
+            ub[i, j] = in_domain and no_conflict
+    
+            already_assigned = submission["submission_id"] in reviewer["assigned_submission_ids"]
+            lb[i, j] = already_assigned
 
-submission_constraints = np.zeros((n_submissions, n_reviewers, n_submissions))  # constraints on reviews per submission
-reviewer_constraints = np.zeros(
-    (n_reviewers, n_reviewers, n_submissions)
-)  # constraints on submissions per reviewer. 1 in all the places where reviewer could be assigned
+    return lb, ub
 
-# Establish lower and upper bounds
-# reviewer cannot be assigned out of domain
-# reviewer must be re-assigned previous assignments
-for i, reviewer in enumerate(reviewers):
-    for j, submission in enumerate(submissions):
-        # each variable is assignment of a submission j to a reviewer i
-        # everyone can be assigned a tutorial because we're short on tutorial reviewers
-        in_domain = submission["track"] in reviewer["tracks"] or (
-            ASSIGN_TUTORIALS_TO_ANYONE and submission["track"] == "TUT"
-        )
-        no_conflict = submission["submission_id"] not in reviewer["conflicts_submission_ids"]
-        ub[i, j] = in_domain and no_conflict
+def create_constraints(reviewers, submissions, min_reviews, max_reviews, min_reviewers, max_reviewers):
+    n_reviewers = len(reviewers)
+    n_submissions = len(submissions)
 
-        already_assigned = submission["submission_id"] in reviewer["assigned_submission_ids"]
-        lb[i, j] = already_assigned
+    submission_constraints = np.zeros((n_submissions, n_reviewers, n_submissions))  # constraints on reviews per submission
+    reviewer_constraints = np.zeros(
+        (n_reviewers, n_reviewers, n_submissions)
+    )  # constraints on submissions per reviewer. 1 in all the places where reviewer could be assigned
+    
+    # Constraints
+    # each reviewer assigned < max reviews
+    for i, reviewer in enumerate(reviewers):
+        reviewer_constraints[i, i, :] = 1
+    reviewer_constraints = reviewer_constraints.reshape(n_reviewers, -1)
+    
+    # each paper assigned to 4 reviewers
+    for j, _ in enumerate(submissions):
+        submission_constraints[j, :, j] = 1
+    submission_constraints = submission_constraints.reshape(n_submissions, -1)
+    
+    submission_per_reviewer_constraint = LinearConstraint(
+        reviewer_constraints, min_reviews, max_reviews
+    )
+    reviews_per_paper_constraint = LinearConstraint(
+        submission_constraints, min_reviewers, max_reviewers
+    )
+    constraints = [submission_per_reviewer_constraint, reviews_per_paper_constraint]
+ 
+    return constraints
 
-# Constraints
-# each reviewer assigned < max reviews
-for i, reviewer in enumerate(reviewers):
-    reviewer_constraints[i, i, :] = 1
-reviewer_constraints = reviewer_constraints.reshape(n_reviewers, -1)
+def solve_milp(df_reviewers, df_submissions, min_reviews, max_reviews, min_reviewers, max_reviewers, tutorial_coeff, assign_tutorials_to_anyone):
+    reviewers = df_reviewers.to_dict("records")
+    submissions = df_submissions.to_dict("records")
 
-# each paper assigned to 4 reviewers
-for j, _ in enumerate(submissions):
-    submission_constraints[j, :, j] = 1
-submission_constraints = submission_constraints.reshape(n_submissions, -1)
-
-bounds = Bounds(lb.ravel(), ub.ravel())
-submission_per_reviewer_constraint = LinearConstraint(
-    reviewer_constraints, MIN_REVIEWS_PER_PERSON, MAX_REVIEWS_PER_PERSON
-)
-reviews_per_paper_constraint = LinearConstraint(
-    submission_constraints, MIN_REVIEWERS_PER_SUBMISSION, MAX_REVIEWERS_PER_SUBMISSION
-)
-constraints = [submission_per_reviewer_constraint, reviews_per_paper_constraint]
-
-# Run MILP
-res = milp(objective_fun, integrality=True, bounds=bounds, constraints=constraints)
-print(res)
-
-# %%
-x = np.round(res.x).astype(bool)
-solution = x.reshape(n_reviewers, n_submissions)
+    objective_fun = create_objective_fun(df_reviewers, df_submissions, tutorial_coeff)
+    lb, ub = create_lb_ub(reviewers, submissions, assign_tutorials_to_anyone)
+    bounds = Bounds(lb.ravel(), ub.ravel())
+    constraints = create_constraints(
+        reviewers,
+        submissions,
+        min_reviews,
+        max_reviews,
+        min_reviewers,
+        max_reviewers
+    )
+    
+    # Run MILP
+    res = milp(objective_fun, integrality=True, bounds=bounds, constraints=constraints)
+    print(res)
+    n_reviewers = len(reviewers)
+    n_submissions = len(submissions)
+    
+    # %%
+    if res.success:
+        x = np.round(res.x).astype(bool)
+        solution = x.reshape(n_reviewers, n_submissions)
+        return solution
 
 # %%
 ############################
 ## FORMAT AND OUTPUT DATA ##
 ############################
-for reviewer, assignments in zip(reviewers, solution):
-    reviewer["assigned_submission_ids"] = df_submissions.submission_id[assignments].values.tolist()
+def format_and_output_result(df_reviewers, df_submissions, solution, post_fix=""):
+    reviewers = df_reviewers.to_dict("records")
+    submissions = df_submissions.to_dict("records")
+
+    for reviewer, assignments in zip(reviewers, solution):
+        # reviewer["assigned_submission_ids"] = reviewer["assigned_submission_ids"] + df_submissions.submission_id[assignments].values.tolist()
+        reviewer["assigned_submission_ids"] = df_submissions.submission_id[assignments].values.tolist()
+        if DEBUG:
+            # Check how many tutorials everyone got
+            reviewer["is_tutorial"] = [t == "TUT" for t in df_submissions.track[assignments]]
+            reviewer["num_tutorials"] = sum(reviewer["is_tutorial"])
+            reviewer["num_submissions"] = len(reviewer["assigned_submission_ids"])
+            reviewer["tutorial_reviewer"] = "TUT" in reviewer["tracks"]
+            # Check that each reviewer actually was assigned a submission in their domain
+            reviewer["track_in_domain"] = [t in reviewer["tracks"] for t in df_submissions.track[assignments]]
+    
     if DEBUG:
-        # Check how many tutorials everyone got
-        reviewer["is_tutorial"] = [t == "TUT" for t in df_submissions.track[assignments]]
-        # Check that each reviewer actually was assigned a submission in their domain
-        reviewer["track_in_domain"] = [t in reviewer["tracks"] for t in df_submissions.track[assignments]]
-
-if DEBUG:
-    result = {reviewer["reviewer_id"]: sorted(reviewer["is_tutorial"]) for reviewer in reviewers}
-
-    with open("review-assignments-debug.json", "w") as fp:
+        result = {reviewer["reviewer_id"]: sorted(reviewer["is_tutorial"]) for reviewer in reviewers}
+    
+        with open(f"output/review-assignments-debug{post_fix}.json", "w") as fp:
+            fp.write(json.dumps(result, indent=4))
+    
+    result = {reviewer["reviewer_id"]: reviewer["assigned_submission_ids"] for reviewer in reviewers}
+    
+    with open(f"output/review-assignments{post_fix}.json", "w") as fp:
+        fp.write(json.dumps(result, indent=4))
+    
+    for submission, assignments in zip(submissions, solution.T):
+        submission["assigned_reviewer_ids"] = df_reviewers.reviewer_id[assignments].values.tolist()
+    
+    result = {submission["submission_id"]: submission["assigned_reviewer_ids"] for submission in submissions}
+    
+    with open(f"output/submission-assignments{post_fix}.json", "w") as fp:
         fp.write(json.dumps(result, indent=4))
 
-result = {reviewer["reviewer_id"]: reviewer["assigned_submission_ids"] for reviewer in reviewers}
-
-with open("review-assignments.json", "w") as fp:
-    fp.write(json.dumps(result, indent=4))
-
-for submission, assignments in zip(submissions, solution.T):
-    submission["assigned_reviewer_ids"] = df_reviewers.reviewer_id[assignments].values.tolist()
-
-result = {submission["submission_id"]: submission["assigned_reviewer_ids"] for submission in submissions}
-
-with open("submission-assignments.json", "w") as fp:
-    fp.write(json.dumps(result, indent=4))
-
-# %%
+    return reviewers, submissions

--- a/notebooks/Pre-processing.ipynb
+++ b/notebooks/Pre-processing.ipynb
@@ -1,0 +1,670 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f0334ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "\n",
+    "# Raw data to import\n",
+    "raw_files = dict(\n",
+    "    scipy_reviewers = \"../data/scipy_2024_reviewers_export_031024_201500.csv\", # people who signed up as reviewers\n",
+    "    pretalx_sessions = \"../data/2024_sessions.csv\", # all proposal exported from pretalx\n",
+    "    pretalx_speakers = \"../data/2024_speakers.csv\", # all speakers exported from pretalx\n",
+    "    pretalx_reviewers = \"../data/pretalx_reviewers_031024_212500.csv\", # all reviewers copy-pasted from pretalx\n",
+    "    coi_reviewers = \"../data/scipy_2024_coi_export_031024_220100.csv\", # all responses to the coi form\n",
+    "    coi_authors = \"../data/coi_authors.csv\", # copy pasted values of author names from coi form\n",
+    "    tracks = \"../data/tracks.csv\" # manually entered track IDs\n",
+    ")\n",
+    "\n",
+    "# Output\n",
+    "database_file = \"../data/assign_reviews_031024.db\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03d0f519",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect(database_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ce918a8-7441-4e64-bcf6-a3e6e8f864aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_and_show_table(file_name, table_name, show=True):\n",
+    "    con.sql(f\"create or replace table {table_name} as select * from read_csv(\\\"{file_name}\\\", header=true)\")\n",
+    "    if show is True:\n",
+    "        return con.sql(f\"table {table_name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd7267b9-c1f5-45c1-996b-af93c7b02f08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython import display\n",
+    "for table_name, file_name in raw_files.items():\n",
+    "    print(table_name)\n",
+    "    display.display(create_and_show_table(file_name, table_name).df())\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7570eed-6187-4b40-ac8c-ed25e4beb8cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "table tracks\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2924fa43-915c-4c63-b715-08e2075983e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "with dupes as\n",
+    "    (\n",
+    "        select\n",
+    "            name,\n",
+    "            num,\n",
+    "            email\n",
+    "        from\n",
+    "            (\n",
+    "                select\n",
+    "                    name,\n",
+    "                    count(*) as num,\n",
+    "                    string_agg(Email) as email\n",
+    "                from\n",
+    "                    scipy_reviewers\n",
+    "                    group by Name\n",
+    "            )\n",
+    "            where\n",
+    "                num>1\n",
+    "        )\n",
+    "\n",
+    "select * from dupes\n",
+    "\"\"\").df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04ea463b-4151-4dfe-ae2d-08b1c763e9a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "select count(*) from scipy_reviewers\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd8ddb47-daf1-4ac7-abfa-39f7d839be13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "select count(*) from pretalx_reviewers\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11439a50-cfbb-403b-a0fa-cf4b91f31e11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "select count(*) from coi_reviewers\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55e81f6d-c8c9-4cfc-9770-db731068c55f",
+   "metadata": {},
+   "source": [
+    "This is a table with all reviewers who\n",
+    "1. signed up\n",
+    "2. created an account on pretalx\n",
+    "3. submitted the COI form"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b9ecee5-ae65-4c49-8e6c-4ebcd6a796f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "create or replace table reviewers as\n",
+    "    select\n",
+    "        scipy_reviewers.Name as name,\n",
+    "        scipy_reviewers.Email as email,\n",
+    "        \\\"Track(s) to review for (check all that apply)\\\" as tracks,\n",
+    "        \\\"Mark the speaker(s) or company/organization/affiliation(s) that could pose a conflict of interest\\\" as coi\n",
+    "    from scipy_reviewers\n",
+    "    join pretalx_reviewers on scipy_reviewers.Email = pretalx_reviewers.Email\n",
+    "    join coi_reviewers on coi_reviewers.Email = pretalx_reviewers.Email\n",
+    "\"\"\")\n",
+    "\n",
+    "df = con.sql(\"select distinct * from reviewers\").df()\n",
+    "num_reviewers = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "461de254-93e5-4a97-b7d5-3074df212fdb",
+   "metadata": {},
+   "source": [
+    "Reviewers who signed up for pretalx but did not fill in COI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4221ff7c-c824-4517-820c-1f8323d95970",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con = duckdb.connect(database_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b70bc5b8-118a-43a4-9b07-2d6dbc59eb1a",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"select * from pretalx_reviewers anti join coi_reviewers on pretalx_reviewers.Email = coi_reviewers.Email\").df()\n",
+    "num_pretalx_no_coi = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64d329e5-88f2-4107-a33f-59bdf1a98c8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df.to_csv(\"input/signed_up_for_pretalx_no_coi.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c475b2b-ac98-495d-94e8-5135366523e2",
+   "metadata": {},
+   "source": [
+    "Reviewers who filled in COI but did not sign up for pretalx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "868dcd1e-8f4a-4e01-8ad2-0538d8b4557d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"select * from coi_reviewers anti join pretalx_reviewers on coi_reviewers.Email = pretalx_reviewers.Email\").df()\n",
+    "num_coi_no_pretalx = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1b6f1c8-e00f-4e79-ad6c-f509591a362a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df.to_csv(\"input/submitted_coi_no_pretalx.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c493bc49-adbc-4173-a9c0-38178c7e8135",
+   "metadata": {},
+   "source": [
+    "People who signed up as reviewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edf7bf56-7884-49fa-811c-0e5b3c3c5e92",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"\"\"\n",
+    "select distinct * from scipy_reviewers\n",
+    "\"\"\").df()\n",
+    "num_signed_up = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0025d41a-ecf6-4c08-985f-3e30807675e3",
+   "metadata": {},
+   "source": [
+    "People who signed up as reviewer and didn't sign up for pretalx nor submitted COI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4feef06c-985a-485c-b4f1-73d87c2f8f1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"\"\"\n",
+    "with no_coi as\n",
+    "(select * from pretalx_reviewers anti join coi_reviewers on pretalx_reviewers.Email = coi_reviewers.Email),\n",
+    "no_pretalx as\n",
+    "(select * from coi_reviewers anti join pretalx_reviewers on coi_reviewers.Email = pretalx_reviewers.Email)\n",
+    "select distinct * from scipy_reviewers\n",
+    "join no_coi on no_coi.Name = scipy_reviewers.Name\n",
+    "join no_pretalx on no_pretalx.Name = no_coi.Name\n",
+    "\"\"\").df()\n",
+    "num_no_show = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "492879e0-3835-4e8e-bfb0-3a85cc3fc541",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df.to_csv(\"input/no_pretalx_and_no_coi.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29faf2df-6c56-447a-9303-30e297ad4ca7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"\"\"\n",
+    "select distinct * from scipy_reviewers\n",
+    "anti join reviewers on scipy_reviewers.Email = reviewers.email\n",
+    "\"\"\").df()\n",
+    "num_no_show = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad4b6bb5-2698-4246-afd0-2003c9ac6bda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df.to_csv(\"input/all_reviewers_without_assignments.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4e2ebd4-1c7c-47b2-88a5-f12f52e3b132",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_no_show = num_signed_up-num_reviewers-num_pretalx_no_coi-num_coi_no_pretalx\n",
+    "num_partial = sum([num_pretalx_no_coi, num_coi_no_pretalx, num_no_show])\n",
+    "num_reviewers, num_signed_up, num_pretalx_no_coi, num_coi_no_pretalx, num_no_show, num_partial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af12d40a-1f28-4154-9ded-1f358d1d3e06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"select * from reviewers where instr(name, 'eli')\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "223b6992-1f77-44f7-83df-8fae78b30d29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# con.sql(\"table reviewers\").df().to_csv(\"input/reviewers_to_assign_with_name.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbb586ee-df00-4fb9-9d16-e3e5d570c3de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"select * from reviewers where instr(Name, 'Wu')\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d82591ec-8532-4b0b-bcf5-ebbc7275c266",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum([num_pretalx_no_coi, num_coi_no_pretalx, num_reviewers])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1b3cbed-547b-49b8-80e6-4ab0df57b08f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "with dupes as\n",
+    "    (\n",
+    "        select\n",
+    "            *\n",
+    "        from\n",
+    "            (\n",
+    "                select\n",
+    "                    name,\n",
+    "                    count(*) as num,\n",
+    "                    string_agg(email) as email,\n",
+    "                    string_agg(tracks) as tracks,\n",
+    "                    string_agg(coi) as coi\n",
+    "                from\n",
+    "                    reviewers\n",
+    "                    group by name\n",
+    "            )\n",
+    "            where\n",
+    "                num>1\n",
+    "        )\n",
+    "\n",
+    "select * from dupes\n",
+    "\"\"\").df().T.to_json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa1a29e2-b27c-4ed4-a075-4c726e6dda48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"create or replace table reviewers as (select distinct * from reviewers)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a548f2e-6b79-4c28-8b57-1efae53694ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "create or replace table reviewers_with_tracks as\n",
+    "with reviewers_no_dupes as (select distinct * from reviewers)\n",
+    "select reviewers_no_dupes.name, email, list(tracks.name) as tracks, list(tracks.track_id) as track_ids from reviewers_no_dupes\n",
+    "    join tracks on instr(reviewers_no_dupes.tracks, tracks.name)\n",
+    "    group by reviewers_no_dupes.name, email\n",
+    "\"\"\"\n",
+    ")\n",
+    "\n",
+    "con.sql(\"select distinct * from reviewers_with_tracks\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3427dba1-d840-46a2-a304-7a643c1aeee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"select ID as submission_id, \\\"Speaker IDs\\\" as speaker_ids from pretalx_sessions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0657b537-bd53-426a-9345-ceca87f36a73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(f\"\"\"\n",
+    "create or replace table reviewers_with_coi as\n",
+    "\n",
+    "with submissions_with_authors as (\n",
+    "    select\n",
+    "        ID as submission_id,\n",
+    "        \\\"Speaker IDs\\\" as speaker_ids\n",
+    "    from\n",
+    "        pretalx_sessions\n",
+    ")\n",
+    "select\n",
+    "    reviewers.name,\n",
+    "    reviewers.email,\n",
+    "    list(pretalx_speakers.Name) as speakers,\n",
+    "    list(pretalx_speakers.ID) AS speaker_ids,\n",
+    "    list(submissions_with_authors.submission_id) as submission_ids\n",
+    "from\n",
+    "    reviewers\n",
+    "    left join coi_authors on instr(coi, coi_authors.author)\n",
+    "    left join pretalx_speakers on contains(coi_authors.author, pretalx_speakers.Name)\n",
+    "    left join submissions_with_authors on contains(submissions_with_authors.speaker_ids, pretalx_speakers.ID)\n",
+    "group by reviewers.name, reviewers.email\n",
+    "order by reviewers.name\n",
+    "\"\"\"\n",
+    ")\n",
+    "\n",
+    "con.sql(\"table reviewers_with_coi\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffef4114-385b-44b0-9bc1-f21a8a1402ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "with reviewers_with_coi_pre as (\n",
+    "    select name, email, author\n",
+    "    from reviewers\n",
+    "    join coi_authors on instr(coi, coi_authors.author)\n",
+    ")\n",
+    "select count(*), author from reviewers_with_coi_pre anti join pretalx_speakers on contains(reviewers_with_coi_pre.author, pretalx_speakers.Name) group by author\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acdd01c4-eb7b-4f80-a8dc-462a9bc5508b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"table reviewers_with_tracks\").df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90185548-bfdd-47d1-bdac-d95af43b8c0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"select email as reviewer_id, list(track_id) as tracks from reviewers_with_tracks group by email\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adeb8dcc-614c-430e-a65f-932ee13a881c",
+   "metadata": {},
+   "source": [
+    "# Final tables for script"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cac7157c-c2eb-4f2e-bd02-cc2fe788afc4",
+   "metadata": {},
+   "source": [
+    "## reviewers_to_assign"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "183fabc0-a5fa-446d-9375-381cd75ff7c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table reviewers_to_assign as\n",
+    "select\n",
+    "    reviewers_with_coi.email as reviewer_id,\n",
+    "    reviewers_with_tracks.track_ids as tracks,\n",
+    "    reviewers_with_coi.submission_ids as conflicts_submission_ids\n",
+    "from reviewers_with_coi\n",
+    "join reviewers_with_tracks on reviewers_with_tracks.email = reviewers_with_coi.email\n",
+    "\"\"\")\n",
+    "\n",
+    "con.sql(\"table reviewers_to_assign\").df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c1facf8-046c-49e0-b21b-67c2d7b5dc64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# con.sql(\"table reviewers_to_assign\").df().to_csv(\"input/reviewers_to_assign.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f717e8c-9b97-4666-a2c7-80ab491d61af",
+   "metadata": {},
+   "source": [
+    "## submissions_to_assign"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34f07bb1-101e-45f1-8598-e6a459393de9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table submissions_to_assign as\n",
+    "select\n",
+    "    ID as submission_id,\n",
+    "    string_split(\\\"Speaker IDs\\\", '\\n') as author_ids,\n",
+    "    track_id as track\n",
+    "from pretalx_sessions\n",
+    "    join tracks on pretalx_sessions.Track = tracks.name\n",
+    "\"\"\")\n",
+    "\n",
+    "con.sql(\"table submissions_to_assign\").df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59c00158-ce1b-4f58-9cff-dbb34a5cd8af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# con.sql(\"table submissions_to_assign\").df().to_csv(\"input/submissions_to_assign.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2c113b9-e32f-40c9-ab97-df975d12f741",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# con.sql(\"table submissions_to_assign\").df().author_ids.iloc[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5c7a0fd-b18e-4f57-b0ef-23fdd06531ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6dd57d1-49cb-42e3-a774-81b2d2dca2a0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Pre-processing.ipynb
+++ b/notebooks/Pre-processing.ipynb
@@ -279,7 +279,7 @@
    "id": "0025d41a-ecf6-4c08-985f-3e30807675e3",
    "metadata": {},
    "source": [
-    "People who signed up as reviewer and didn't sign up for pretalx nor submitted COI"
+    "People who signed up as reviewer and signed up for pretalx and submitted COI but used different email addresses"
    ]
   },
   {
@@ -290,15 +290,45 @@
    "outputs": [],
    "source": [
     "df = con.sql(\"\"\"\n",
-    "with no_coi as\n",
+    "create or replace table reviewers_with_email_typos as\n",
+    "(with no_coi as\n",
     "(select * from pretalx_reviewers anti join coi_reviewers on pretalx_reviewers.Email = coi_reviewers.Email),\n",
     "no_pretalx as\n",
     "(select * from coi_reviewers anti join pretalx_reviewers on coi_reviewers.Email = pretalx_reviewers.Email)\n",
     "select distinct scipy_reviewers.Name, scipy_reviewers.Email, no_pretalx.Email as no_pretalx_email, no_coi.email as no_coi_email from scipy_reviewers\n",
     "join no_coi on no_coi.Name = scipy_reviewers.Name\n",
-    "join no_pretalx on no_pretalx.Name = no_coi.Name\n",
+    "join no_pretalx on no_pretalx.Name = no_coi.Name)\n",
+    "\"\"\")\n",
+    "df = con.sql(\"table reviewers_with_email_typos\").df()\n",
+    "num_typos = len(df)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a2c83c8-29e2-412e-b84e-ab4944e650c4",
+   "metadata": {},
+   "source": [
+    "People who signed up as reviewer and signed up for pretalx and submitted COI but used different names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf854063-4a88-4be2-8cd9-04fd78f1cf9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"\"\"\n",
+    "(with no_coi as\n",
+    "(select * from pretalx_reviewers anti join coi_reviewers on pretalx_reviewers.Email = coi_reviewers.Email),\n",
+    "no_pretalx as\n",
+    "(select * from coi_reviewers anti join pretalx_reviewers on coi_reviewers.Email = pretalx_reviewers.Email)\n",
+    "select distinct scipy_reviewers.Name, scipy_reviewers.Email, no_pretalx.Name as no_pretalx_name, no_coi.name as no_coi_name from scipy_reviewers\n",
+    "join no_coi on no_coi.Email = scipy_reviewers.Email\n",
+    "join no_pretalx on no_pretalx.Email = no_coi.Email)\n",
     "\"\"\").df()\n",
-    "num_no_show = len(df)\n",
+    "num_typos_name = len(df)\n",
     "df"
    ]
   },
@@ -310,6 +340,34 @@
    "outputs": [],
    "source": [
     "# df.to_csv(\"input/reviewers_multi_email.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e7c6208-0e73-4447-b749-578b7f84f5a9",
+   "metadata": {},
+   "source": [
+    "People who signed up as reviewer and didn't sign up for pretalx nor submitted COI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7bf3576-78e6-4367-abc0-f48e250807e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = con.sql(\"\"\"\n",
+    "(with no_coi as\n",
+    "(select * from pretalx_reviewers anti join coi_reviewers on pretalx_reviewers.Email = coi_reviewers.Email),\n",
+    "no_pretalx as\n",
+    "(select * from coi_reviewers anti join pretalx_reviewers on coi_reviewers.Email = pretalx_reviewers.Email)\n",
+    "select distinct scipy_reviewers.Name, scipy_reviewers.Email from scipy_reviewers\n",
+    "anti join reviewers on reviewers.Name = scipy_reviewers.Name\n",
+    "anti join no_coi on no_coi.Name = scipy_reviewers.Name\n",
+    "anti join no_pretalx on no_pretalx.Name = scipy_reviewers.Name)\n",
+    "\"\"\").df()\n",
+    "df"
    ]
   },
   {

--- a/notebooks/Pre-processing.ipynb
+++ b/notebooks/Pre-processing.ipynb
@@ -294,7 +294,7 @@
     "(select * from pretalx_reviewers anti join coi_reviewers on pretalx_reviewers.Email = coi_reviewers.Email),\n",
     "no_pretalx as\n",
     "(select * from coi_reviewers anti join pretalx_reviewers on coi_reviewers.Email = pretalx_reviewers.Email)\n",
-    "select distinct * from scipy_reviewers\n",
+    "select distinct scipy_reviewers.Name, scipy_reviewers.Email, no_pretalx.Email as no_pretalx_email, no_coi.email as no_coi_email from scipy_reviewers\n",
     "join no_coi on no_coi.Name = scipy_reviewers.Name\n",
     "join no_pretalx on no_pretalx.Name = no_coi.Name\n",
     "\"\"\").df()\n",
@@ -305,11 +305,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "492879e0-3835-4e8e-bfb0-3a85cc3fc541",
+   "id": "eb7b392a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# df.to_csv(\"input/no_pretalx_and_no_coi.csv\")"
+    "# df.to_csv(\"input/reviewers_multi_email.csv\")"
    ]
   },
   {

--- a/notebooks/Pre-processing.ipynb
+++ b/notebooks/Pre-processing.ipynb
@@ -11,17 +11,17 @@
     "\n",
     "# Raw data to import\n",
     "raw_files = dict(\n",
-    "    scipy_reviewers = \"../data/scipy_2024_reviewers_export_031024_201500.csv\", # people who signed up as reviewers\n",
-    "    pretalx_sessions = \"../data/2024_sessions.csv\", # all proposal exported from pretalx\n",
-    "    pretalx_speakers = \"../data/2024_speakers.csv\", # all speakers exported from pretalx\n",
-    "    pretalx_reviewers = \"../data/pretalx_reviewers_031024_212500.csv\", # all reviewers copy-pasted from pretalx\n",
-    "    coi_reviewers = \"../data/scipy_2024_coi_export_031024_220100.csv\", # all responses to the coi form\n",
+    "    scipy_reviewers = \"../data/scipy_reviewers.csv\", # people who signed up as reviewers\n",
+    "    pretalx_sessions = \"../data/sessions.csv\", # all proposal exported from pretalx\n",
+    "    pretalx_speakers = \"../data/speakers.csv\", # all speakers exported from pretalx\n",
+    "    pretalx_reviewers = \"../data/pretalx_reviewers.csv\", # all reviewers copy-pasted from pretalx\n",
+    "    coi_reviewers = \"../data/scipy_coi_export.csv\", # all responses to the coi form\n",
     "    coi_authors = \"../data/coi_authors.csv\", # copy pasted values of author names from coi form\n",
     "    tracks = \"../data/tracks.csv\" # manually entered track IDs\n",
     ")\n",
     "\n",
     "# Output\n",
-    "database_file = \"../data/assign_reviews_031024.db\""
+    "database_file = \"../data/assign_reviews.db\""
    ]
   },
   {

--- a/notebooks/Run-assignments.ipynb
+++ b/notebooks/Run-assignments.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "DEBUG = True\n",
     "\n",
-    "database_file = \"../data/assign_reviews_031024.db\"\n",
+    "database_file = \"../data/assign_reviews.db\"\n",
     "con = duckdb.connect(database_file)\n",
     "df_submissions = con.sql(\"table submissions_to_assign\").df()\n",
     "df_reviewers = con.sql(\"table reviewers_to_assign\").df()\n",
@@ -77,7 +77,7 @@
    "id": "34384f90-6f5a-42b6-b6d6-b27c756ee9b8",
    "metadata": {},
    "source": [
-    "## Assign tutorial reviewers"
+    "## Step 1. Assign tutorial reviewers"
    ]
   },
   {
@@ -182,7 +182,7 @@
    "id": "d303b378-63ff-405c-aaf1-4af51f09bfea",
    "metadata": {},
    "source": [
-    "## Assign talk reviewers"
+    "## Step 2. Assign talk reviewers"
    ]
   },
   {
@@ -318,7 +318,7 @@
    "id": "b7c3c63e-908b-474a-ab02-02873b89b942",
    "metadata": {},
    "source": [
-    "## Assign talks to tutorial reviewers"
+    "## Step 3. Assign talks to tutorial reviewers"
    ]
   },
   {
@@ -556,7 +556,7 @@
    "outputs": [],
    "source": [
     "import duckdb\n",
-    "database_file = \"../data/assign_reviews_031024.db\"\n",
+    "database_file = \"../data/assign_reviews.db\"\n",
     "con = duckdb.connect(database_file)"
    ]
   },

--- a/notebooks/Run_031124.ipynb
+++ b/notebooks/Run_031124.ipynb
@@ -1,0 +1,620 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbfa2c54-c1f1-4241-bc27-91fc1b1265bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %%\n",
+    "####################\n",
+    "## ASSIGN REVIEWS ##\n",
+    "####################\n",
+    "# Imports\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import duckdb\n",
+    "\n",
+    "import sys\n",
+    "sys.path.append(\"..\")\n",
+    "from assign_reviews import create_objective_fun, create_lb_ub, create_constraints, solve_milp, format_and_output_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad38296b-0b09-4c67-bff3-37943db918b1",
+   "metadata": {},
+   "source": [
+    "# Start script"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b72db3b-80e4-41b5-992c-e01edc0c223e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mkdir output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e0ec716-20a4-470b-9aea-5dc5853be804",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ASSIGN_TUTORIALS_TO_ANYONE = False\n",
+    "TUTORIAL_COEFF = 0.8\n",
+    "\n",
+    "DEBUG = True\n",
+    "\n",
+    "database_file = \"../data/assign_reviews_031024.db\"\n",
+    "con = duckdb.connect(database_file)\n",
+    "df_submissions = con.sql(\"table submissions_to_assign\").df()\n",
+    "df_reviewers = con.sql(\"table reviewers_to_assign\").df()\n",
+    "\n",
+    "df_submissions = df_submissions.assign(assigned_reviewer_ids=[[]] * len(df_submissions))\n",
+    "df_reviewers = df_reviewers.assign(assigned_submission_ids=[[]] * len(df_reviewers))\n",
+    "\n",
+    "len(df_submissions), len(df_reviewers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef711304-a232-4b5f-a5f2-08ae410c8d62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_submissions[df_submissions.track==\"TUT\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34384f90-6f5a-42b6-b6d6-b27c756ee9b8",
+   "metadata": {},
+   "source": [
+    "## Assign tutorial reviewers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6e46cab-603a-4c28-8d75-bcbf982cdb56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MIN_TUTORIALS_PER_PERSON = 0\n",
+    "MAX_TUTORIALS_PER_PERSON = 5\n",
+    "MIN_REVIEWERS_PER_TUTORIAL = 3\n",
+    "MAX_REVIEWERS_PER_TUTORIAL = 4\n",
+    "\n",
+    "df_submissions_tutorials = df_submissions[df_submissions.track==\"TUT\"]\n",
+    "\n",
+    "solution = solve_milp(\n",
+    "    df_reviewers,\n",
+    "    df_submissions_tutorials,\n",
+    "    MIN_TUTORIALS_PER_PERSON,\n",
+    "    MAX_TUTORIALS_PER_PERSON,\n",
+    "    MIN_REVIEWERS_PER_TUTORIAL,\n",
+    "    MAX_REVIEWERS_PER_TUTORIAL,\n",
+    "    TUTORIAL_COEFF,\n",
+    "    ASSIGN_TUTORIALS_TO_ANYONE\n",
+    ")\n",
+    "reviewers, submissions = format_and_output_result(df_reviewers, df_submissions_tutorials, solution, post_fix=\"00\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7109479e-3e56-4ef0-9f17-1be5e9d6f7f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(reviewers)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "029c405c-48fb-4598-896e-e0227e9b6987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_reviewers_with_tut = df_reviewers.assign(assigned_submission_ids=df.assigned_submission_ids)\n",
+    "df_reviewers_with_tut"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ee582a7-e840-4273-ae03-aa88d1912157",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"select * from df_reviewers_with_tut\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c3195a4-2baf-4dd0-a7b3-62ce193e00fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"create or replace table reviewer_assignments_00 as select * from df_reviewers_with_tut\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f2fcddf-8573-4ce5-9e33-ab3c2ff73cc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(submissions)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03146222-8257-446e-820c-89710391d08d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table submission_assignments_00 as\n",
+    "select df_submissions.submission_id, df_submissions.author_ids, df_submissions.track,\n",
+    "list_concat(df_submissions.assigned_reviewer_ids, df.assigned_reviewer_ids) as assigned_reviewer_ids\n",
+    "from df_submissions\n",
+    "left join df on df.submission_id = df_submissions.submission_id\n",
+    "\"\"\")\n",
+    "con.sql(\"table submission_assignments_00\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d303b378-63ff-405c-aaf1-4af51f09bfea",
+   "metadata": {},
+   "source": [
+    "## Assign talk reviewers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9695336-6696-4dc3-86eb-9d0eea82bcea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_reviewers_with_tut[df_reviewers_with_tut.assigned_submission_ids.apply(len) == 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0174c6e7-0feb-4073-9ee7-0f994439dd2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MIN_REVIEWS_PER_PERSON = 5\n",
+    "MAX_REVIEWS_PER_PERSON = 9\n",
+    "MIN_REVIEWERS_PER_SUBMISSION = 2\n",
+    "MAX_REVIEWERS_PER_SUBMISSION = 4\n",
+    "\n",
+    "df_reviewers_no_submissions = df_reviewers_with_tut[df_reviewers_with_tut.assigned_submission_ids.apply(len) == 0]\n",
+    "df_submissions_no_tutorials = df_submissions[df_submissions.track!=\"TUT\"]\n",
+    "\n",
+    "solution = solve_milp(\n",
+    "    df_reviewers_no_submissions,\n",
+    "    df_submissions_no_tutorials,\n",
+    "    MIN_REVIEWS_PER_PERSON,\n",
+    "    MAX_REVIEWS_PER_PERSON,\n",
+    "    MIN_REVIEWERS_PER_SUBMISSION,\n",
+    "    MAX_REVIEWERS_PER_SUBMISSION,\n",
+    "    TUTORIAL_COEFF,\n",
+    "    ASSIGN_TUTORIALS_TO_ANYONE\n",
+    ")\n",
+    "if solution is not None:\n",
+    "    reviewers, submissions = format_and_output_result(df_reviewers_no_submissions, df_submissions_no_tutorials, solution, post_fix=\"01\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "941e4ea6-e3d0-4da5-bb32-9c1bbb6698bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_reviewers_with_tut"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e56630ab-54b5-4c81-a91b-0ee795f6ac35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(reviewers)[[\"reviewer_id\", \"assigned_submission_ids\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa3bc6b2-00a1-4c63-b8c4-816bce8ecead",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4a8cf52-4eba-4231-a779-fcfcd4ae3387",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table reviewer_assignments_01 as\n",
+    "select\n",
+    "    df_reviewers_with_tut.reviewer_id, tracks, conflicts_submission_ids,\n",
+    "    list_concat(df_reviewers_with_tut.assigned_submission_ids, df.assigned_submission_ids) as assigned_submission_ids\n",
+    "from df_reviewers_with_tut\n",
+    "left join df on df.reviewer_id = df_reviewers_with_tut.reviewer_id\n",
+    "\"\"\")\n",
+    "con.sql(\"table reviewer_assignments_01\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "656b2edc-0374-4c66-b7aa-19fb315c73d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(submissions)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a1716c3-d879-4d91-9aae-69601f372f77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table submission_assignments_01 as\n",
+    "select submission_assignments_00.submission_id, submission_assignments_00.author_ids, submission_assignments_00.track,\n",
+    "list_concat(submission_assignments_00.assigned_reviewer_ids, df.assigned_reviewer_ids) as assigned_reviewer_ids\n",
+    "from submission_assignments_00\n",
+    "left join df on df.submission_id = submission_assignments_00.submission_id\n",
+    "\"\"\")\n",
+    "con.sql(\"table submission_assignments_01\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2cc2801-c6c5-417a-9f5d-cf60ee8d3dc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(submissions)\n",
+    "df = df.assign(num_reviewers=df.assigned_reviewer_ids.apply(len))\n",
+    "df[df.num_reviewers>2]\n",
+    "df[df.num_reviewers==2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7c3c63e-908b-474a-ab02-02873b89b942",
+   "metadata": {},
+   "source": [
+    "## Assign talks to tutorial reviewers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1e3d00e-f3bd-4166-b00d-10c9c5c4c2ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(submissions)\n",
+    "df = df.assign(num_reviewers=df.assigned_reviewer_ids.apply(len))\n",
+    "df_submissions_few_reviewers = df[df.num_reviewers==2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2afdf9a9-b4bd-4cbf-b8ec-9148236cc53f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MIN_REVIEWS_PER_PERSON = 0\n",
+    "MAX_REVIEWS_PER_PERSON = 4\n",
+    "MIN_REVIEWERS_PER_SUBMISSION = 1\n",
+    "MAX_REVIEWERS_PER_SUBMISSION = 2\n",
+    "\n",
+    "df_reviewers_only_tut = df_reviewers_with_tut[df_reviewers_with_tut.assigned_submission_ids.apply(len) > 0]\n",
+    "\n",
+    "solution = solve_milp(\n",
+    "    df_reviewers_only_tut,\n",
+    "    df_submissions_few_reviewers,\n",
+    "    MIN_REVIEWS_PER_PERSON,\n",
+    "    MAX_REVIEWS_PER_PERSON,\n",
+    "    MIN_REVIEWERS_PER_SUBMISSION,\n",
+    "    MAX_REVIEWERS_PER_SUBMISSION,\n",
+    "    TUTORIAL_COEFF,\n",
+    "    ASSIGN_TUTORIALS_TO_ANYONE\n",
+    ")\n",
+    "\n",
+    "if solution is not None:\n",
+    "    reviewers, submissions = format_and_output_result(df_reviewers_only_tut, df_submissions_few_reviewers, solution, post_fix=\"02\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ddc69f0-6408-4d4a-91eb-7e1d967aa6ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(submissions)\n",
+    "df = df.assign(num_reviewers=df.assigned_reviewer_ids.apply(len))\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6dcb32f-b32a-42ea-b36c-49674f39ecb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(reviewers)\n",
+    "df = df[[\"reviewer_id\", \"assigned_submission_ids\"]]\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "132eb314-268d-4778-bce1-dda40cbdd2a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table reviewer_assignments_02 as\n",
+    "select\n",
+    "    reviewer_assignments_01.reviewer_id, tracks, conflicts_submission_ids,\n",
+    "    list_concat(reviewer_assignments_01.assigned_submission_ids, df.assigned_submission_ids) as assigned_submission_ids\n",
+    "from reviewer_assignments_01\n",
+    "left join df on df.reviewer_id = reviewer_assignments_01.reviewer_id\n",
+    "\"\"\")\n",
+    "con.sql(\"table reviewer_assignments_02\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5397c3f-d63f-493e-908a-47e857e09f57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"select count(*), string_agg(reviewer_id), len(assigned_submission_ids) as num_submissions from reviewer_assignments_02 group by num_submissions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e57c7c6-d2f4-4742-83cb-f876f01574ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(submissions)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12ecbfa5-60bc-4c13-b209-cb686aa04c7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "create or replace table submission_assignments_02 as\n",
+    "select submission_assignments_01.submission_id, submission_assignments_01.author_ids, submission_assignments_01.track,\n",
+    "list_concat(submission_assignments_01.assigned_reviewer_ids, df.assigned_reviewer_ids) as assigned_reviewer_ids\n",
+    "from submission_assignments_01\n",
+    "left join df on df.submission_id = submission_assignments_01.submission_id\n",
+    "\"\"\")\n",
+    "con.sql(\"table submission_assignments_02\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8186a06-981a-4f88-bde7-be4479c57697",
+   "metadata": {},
+   "source": [
+    "## Final counts/checks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "135ef2a0-69ab-4b76-afc4-41e898ee9083",
+   "metadata": {},
+   "source": [
+    "All submissions have at least 3 reviewers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8719243-645d-40d1-97ee-36e21f6cfdc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "select string_agg(submission_id), count(track), len(assigned_reviewer_ids) from submission_assignments_02 group by len(assigned_reviewer_ids)\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de1edcf3-2866-422b-ade4-b9c4caa5bbfd",
+   "metadata": {},
+   "source": [
+    "Step 1: Only tutorial assignments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e3747df-88a0-4ebd-9f3c-4f0d73c4d9ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "select string_agg(reviewer_id), count(reviewer_id), string_agg(tracks), len(assigned_submission_ids) from reviewer_assignments_00 group by len(assigned_submission_ids)\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ff68efd-6ef6-44c0-ae5e-16d8e22e230c",
+   "metadata": {},
+   "source": [
+    "Step 2: Add talks assignments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40ec3a7e-e444-4890-b03b-54abdc90a13d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "select string_agg(reviewer_id), count(reviewer_id), string_agg(tracks), len(assigned_submission_ids) from reviewer_assignments_01 group by len(assigned_submission_ids)\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7be6ab3a-21d5-46f5-bcb1-5d1ed79573f7",
+   "metadata": {},
+   "source": [
+    "Step 3: Assign talks to tutorial reviewers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acea73f1-c7b1-4d32-8cca-2ab37ef6ab67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "select string_agg(reviewer_id), count(reviewer_id), string_agg(tracks), len(assigned_submission_ids) from reviewer_assignments_02 group by len(assigned_submission_ids)\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa5491c1-7086-4b54-ac34-8dd541f94767",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f993a8fb-25e1-4250-bbd6-8e67cf662659",
+   "metadata": {},
+   "source": [
+    "## Final export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e67db9e7-5ca8-40e9-b90b-1a4dd97fb05d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import duckdb\n",
+    "database_file = \"../data/assign_reviews_031024.db\"\n",
+    "con = duckdb.connect(database_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "585bbb58-3582-41b9-b805-b9a607508f5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "reviewer_assignments_final = {\n",
+    "    item[\"reviewer_id\"]: item[\"assigned_submission_ids\"]\n",
+    "    for item in\n",
+    "    con.sql(\"table reviewer_assignments_02\").df()[[\"reviewer_id\", \"assigned_submission_ids\"]].to_dict(\"records\")\n",
+    "}\n",
+    "with open(f\"output/reviewer-assignments.json\", \"w\") as fp:\n",
+    "        fp.write(json.dumps(reviewer_assignments_final, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c502cf9b-f573-4565-bc59-b98e0c0070b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f88e36e-9b7e-4c4e-a43d-b7248a2f0f1e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 scipy  # requires numpy
 pandas
+jupyter
+duckdb
+duckdb_engine


### PR DESCRIPTION
## Purpose
Add notebooks to pre-process data and assign reviews to SciPy proposals.
The assignment happens in 3 steps:
1. Assign tutorials to all reviewers who have signed up to review tutorials
2. Assign talks to all reviewers who have signed up to review talks and _no_ tutorials
3. Assign talks to reviewers who have signed up to review talks _and_ tutorials

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the notebook with the files exported from Pretalx, COI form and reviewer sign-up form

## Other Information
Some input data is entered manually, please refer to notebook for instructions or contact Program committee