### PR TITLE
feat: Make notebooks runnable on previous data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ venv/
 *.ipynb
 # pixi environments
 .pixi
+
+data/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,37 @@ The checks and tests are all run using Github actions on every pull request and 
 
 This repository is setup for Python 3.11. To customize that, change the `VARIANT` argument in `.devcontainer/devcontainer.json`, change the config options in `.precommit-config.yaml` and change the version number in `.github/workflows/python.yaml`.
 
+## Assign Reviewers
+
+First download the following files from Pretalx into the `data/` directory:
+
+* `scipy_reviewers.csv`  # people who signed up as reviewers
+* `sessions.csv`  # all proposal exported from pretalx
+* `speakers.csv`  # all speakers exported from pretalx
+* `pretalx_reviewers.csv`  # all reviewers copy-pasted from pretalx
+* `scipy_coi_export.csv`  # all responses to the coi form
+* `coi_authors.csv`  # copy pasted values of author names from coi form
+* `tracks.csv`  # manually entered track IDs
+
+Then run the notebooks as Python files in the following order with `pixi`
+
+```
+$ pixi run pre-processing
+$ pixi run assignments
+```
+
+or run the notebooks manually as Jupyter notebooks either by asking for a JupyterLab instance
+
+```
+$ pixi run jupyter lab
+```
+
+or just getting a shell
+
+```
+$ pixi shell
+```
+
 ## Development instructions
 
 ## With devcontainer

--- a/assign_reviews.py
+++ b/assign_reviews.py
@@ -4,6 +4,7 @@
 ####################
 # Imports
 import json
+from pathlib import Path
 
 import numpy as np
 from scipy.optimize import Bounds, LinearConstraint, milp
@@ -120,7 +121,7 @@ def solve_milp(
 ############################
 ## FORMAT AND OUTPUT DATA ##
 ############################
-def format_and_output_result(df_reviewers, df_submissions, solution, post_fix=""):
+def format_and_output_result(df_reviewers, df_submissions, solution, post_fix="", output_dir=Path.cwd() / "output"):
     reviewers = df_reviewers.to_dict("records")
     submissions = df_submissions.to_dict("records")
 
@@ -140,12 +141,12 @@ def format_and_output_result(df_reviewers, df_submissions, solution, post_fix=""
     if DEBUG:
         result = {reviewer["reviewer_id"]: sorted(reviewer["is_tutorial"]) for reviewer in reviewers}
 
-        with open(f"output/review-assignments-debug{post_fix}.json", "w") as fp:
+        with open(output_dir / f"review-assignments-debug{post_fix}.json", "w") as fp:
             fp.write(json.dumps(result, indent=4))
 
     result = {reviewer["reviewer_id"]: reviewer["assigned_submission_ids"] for reviewer in reviewers}
 
-    with open(f"output/review-assignments{post_fix}.json", "w") as fp:
+    with open(output_dir / f"review-assignments{post_fix}.json", "w") as fp:
         fp.write(json.dumps(result, indent=4))
 
     for submission, assignments in zip(submissions, solution.T):
@@ -153,7 +154,7 @@ def format_and_output_result(df_reviewers, df_submissions, solution, post_fix=""
 
     result = {submission["submission_id"]: submission["assigned_reviewer_ids"] for submission in submissions}
 
-    with open(f"output/submission-assignments{post_fix}.json", "w") as fp:
+    with open(output_dir / f"submission-assignments{post_fix}.json", "w") as fp:
         fp.write(json.dumps(result, indent=4))
 
     return reviewers, submissions

--- a/notebooks/pre-processing.py
+++ b/notebooks/pre-processing.py
@@ -19,29 +19,34 @@
 #     name: python
 #     nbconvert_exporter: python
 #     pygments_lexer: ipython3
-#     version: 3.12.1
+#     version: 3.12.2
 # ---
 
 # %%
+from pathlib import Path
+
 import duckdb
 from IPython import display
 
+# %%
+data_dir = Path.cwd() / ".." / "data"
+
 # Raw data to import
 raw_files = dict(
-    scipy_reviewers="../data/scipy_reviewers.csv",  # people who signed up as reviewers
-    pretalx_sessions="../data/sessions.csv",  # all proposal exported from pretalx
-    pretalx_speakers="../data/speakers.csv",  # all speakers exported from pretalx
-    pretalx_reviewers="../data/pretalx_reviewers.csv",  # all reviewers copy-pasted from pretalx
-    coi_reviewers="../data/scipy_coi_export.csv",  # all responses to the coi form
-    coi_authors="../data/coi_authors.csv",  # copy pasted values of author names from coi form
-    tracks="../data/tracks.csv",  # manually entered track IDs
+    scipy_reviewers=data_dir / "scipy_reviewers.csv",  # people who signed up as reviewers
+    pretalx_sessions=data_dir / "sessions.csv",  # all proposal exported from pretalx
+    pretalx_speakers=data_dir / "speakers.csv",  # all speakers exported from pretalx
+    pretalx_reviewers=data_dir / "pretalx_reviewers.csv",  # all reviewers copy-pasted from pretalx
+    coi_reviewers=data_dir / "scipy_coi_export.csv",  # all responses to the coi form
+    coi_authors=data_dir / "coi_authors.csv",  # copy pasted values of author names from coi form
+    tracks=data_dir / "tracks.csv",  # manually entered track IDs
 )
 
 # Output
-database_file = "../data/assign_reviews.db"
+database_file = data_dir / "assign_reviews.db"
 
 # %%
-con = duckdb.connect(database_file)
+con = duckdb.connect(str(database_file))
 
 
 # %%
@@ -141,7 +146,7 @@ df
 # Reviewers who signed up for pretalx but did not fill in COI
 
 # %%
-con = duckdb.connect(database_file)
+con = duckdb.connect(str(database_file))
 
 # %%
 df = con.sql(
@@ -411,5 +416,3 @@ con.sql("table submissions_to_assign").df()
 
 # %%
 con.close()
-
-# %%

--- a/notebooks/pre-processing.py
+++ b/notebooks/pre-processing.py
@@ -359,7 +359,7 @@ select count(*), author from reviewers_with_coi_pre anti join pretalx_speakers o
 con.sql("table reviewers_with_tracks").df()
 
 # %%
-con.sql("select email as reviewer_id, list(track_id) as tracks from reviewers_with_tracks group by email")
+con.sql("select email as reviewer_id, list(track_ids) as tracks from reviewers_with_tracks group by email")
 
 # %% [markdown]
 # # Final tables for script

--- a/notebooks/run-assignments.py
+++ b/notebooks/run-assignments.py
@@ -40,7 +40,8 @@ from assign_reviews import format_and_output_result, solve_milp
 # # Start script
 
 # %%
-output_dir = Path().cwd() / "output"
+data_dir = Path().cwd() / ".." / "data"
+output_dir = Path().cwd() / ".." / "output"
 output_dir.mkdir(exist_ok=True)
 
 # %%
@@ -49,8 +50,8 @@ TUTORIAL_COEFF = 0.8
 
 DEBUG = True
 
-database_file = "../data/assign_reviews.db"
-con = duckdb.connect(database_file)
+database_file = data_dir / "assign_reviews.db"
+con = duckdb.connect(str(database_file))
 df_submissions = con.sql("table submissions_to_assign").df()
 df_reviewers = con.sql("table reviewers_to_assign").df()
 
@@ -83,7 +84,9 @@ solution = solve_milp(
     TUTORIAL_COEFF,
     ASSIGN_TUTORIALS_TO_ANYONE,
 )
-reviewers, submissions = format_and_output_result(df_reviewers, df_submissions_tutorials, solution, post_fix="00")
+reviewers, submissions = format_and_output_result(
+    df_reviewers, df_submissions_tutorials, solution, post_fix="00", output_dir=output_dir
+)
 
 # %%
 df = pd.DataFrame(reviewers)
@@ -142,7 +145,7 @@ solution = solve_milp(
 )
 if solution is not None:
     reviewers, submissions = format_and_output_result(
-        df_reviewers_no_submissions, df_submissions_no_tutorials, solution, post_fix="01"
+        df_reviewers_no_submissions, df_submissions_no_tutorials, solution, post_fix="01", output_dir=output_dir
     )
 
 # %%
@@ -218,7 +221,7 @@ solution = solve_milp(
 
 if solution is not None:
     reviewers, submissions = format_and_output_result(
-        df_reviewers_only_tut, df_submissions_few_reviewers, solution, post_fix="02"
+        df_reviewers_only_tut, df_submissions_few_reviewers, solution, post_fix="02", output_dir=output_dir
     )
 
 # %%
@@ -315,8 +318,8 @@ con.close()
 # ## Final export
 
 # %%
-database_file = "../data/assign_reviews.db"
-con = duckdb.connect(database_file)
+database_file = data_dir / "assign_reviews.db"
+con = duckdb.connect(str(database_file))
 
 # %%
 reviewer_assignments_final = {
@@ -325,7 +328,8 @@ reviewer_assignments_final = {
     .df()[["reviewer_id", "assigned_submission_ids"]]
     .to_dict("records")
 }
-with open("output/reviewer-assignments.json", "w") as fp:
+
+with open(output_dir / "reviewer-assignments.json", "w") as fp:
     fp.write(json.dumps(reviewer_assignments_final, indent=4))
 
 # %%

--- a/notebooks/run-assignments.py
+++ b/notebooks/run-assignments.py
@@ -319,7 +319,7 @@ con = duckdb.connect(database_file)
 
 # %%
 reviewer_assignments_final = {
-    item["reviewer_id"]: item["assigned_submission_ids"]
+    item["reviewer_id"]: item["assigned_submission_ids"].tolist()
     for item in con.sql("table reviewer_assignments_02")
     .df()[["reviewer_id", "assigned_submission_ids"]]
     .to_dict("records")

--- a/notebooks/run-assignments.py
+++ b/notebooks/run-assignments.py
@@ -19,16 +19,16 @@
 #     name: python
 #     nbconvert_exporter: python
 #     pygments_lexer: ipython3
-#     version: 3.12.1
+#     version: 3.12.2
 # ---
 
 # %%
 ####################
 ## ASSIGN REVIEWS ##
 ####################
-# Imports
 import json
 import sys
+from pathlib import Path
 
 import duckdb
 import pandas as pd
@@ -40,7 +40,8 @@ from assign_reviews import format_and_output_result, solve_milp
 # # Start script
 
 # %%
-# mkdir output
+output_dir = Path().cwd() / "output"
+output_dir.mkdir(exist_ok=True)
 
 # %%
 ASSIGN_TUTORIALS_TO_ANYONE = False

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,8 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 
 [tasks]
+pre-processing = "cd notebooks && python pre-processing.py"
+assignments = "cd notebooks && python run-assignments.py"
 
 [dependencies]
 python = "3.12.*"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add a `.gitkeep` for the `data/` directory and also add it to `.gitignore`.
* Fix typo and JSON serialization issues with previous notebooks to allow them to be run from a fresh kernel (using data from Gist previous to 2024-03-31).
* Use `pathlib.Path` to avoid potential errors and allow changing of `output` directory to be at the top level of the project.
* Add `pixi` task runner commands as well as instructions to the README.

As this PR does more than 1 thing, it isn't very atomic (and so less fun to review).  It can be easily split into multiple more atomic PRs though, which I'd be happy to do if that's nicer.

We can also discuss in the 2024-04-01 Program meeting.

(PR was done on plane, but for some reason couldn't get pushed out over plane WiFi, so had to wait till I got to a coffee shop.)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```